### PR TITLE
Pulling and building was redundant

### DIFF
--- a/src/main/java/com/groupon/jenkins/DockerComposeDotCi/DockerPublishPlugin.java
+++ b/src/main/java/com/groupon/jenkins/DockerComposeDotCi/DockerPublishPlugin.java
@@ -93,10 +93,7 @@ public class DockerPublishPlugin extends DotCiPluginAdapter {
                 .replaceAll("_", "").toLowerCase() + buildNumber;
         ShellCommands publishCommands = new ShellCommands();
 
-        // Build everything
-        publishCommands.add(String.format("docker-compose -p %s pull", composeBuildName));
-        publishCommands.add(String.format("docker-compose -p %s build", composeBuildName));
-
+        // Read options from .ci.yml and do things with them
         if (this.options instanceof Map) {
             for (Map.Entry<String, ArrayList<?>> imageMap : ((Map<String, ArrayList<?>>) this.options).entrySet()) {
                 String composeImage = imageMap.getKey();


### PR DESCRIPTION
Removing this code has the effect of not only shortening build times but also removing the plugin's need to know about the docker-compose file. Fixes #8 and #9.
