### PR TITLE
Removing usage of '-f' for docker tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@ Publish a docker image via **DotCI** when using the **docker-compose** build typ
 * [Configuration](#configuration)
   * [Build Tags](#build-tags)
   * [Docker Registry Host](#docker-registry-host)
-  * [Force Push Latest](#force-push-latest)
 * [Logging](#logging)
-* [Known Issues](#known-issues)
-* [TODO](#todo)
 
 ## Usage
 
@@ -75,10 +72,6 @@ You may configure the Docker Registry hostname via `/configure` in Jenkins - loo
 
 This defaults to the public Docker registry (`hub.docker.com`) and can be overwritten in your `.ci.yml`.
 
-### Force Push Latest
-
-This defaults to ***on***, and will force push the `latest` label upon publish.
-
 ## Logging
 
 The plugin writes entries into the build master's catalina logs:
@@ -91,11 +84,3 @@ The plugin writes entries into the build master's catalina logs:
     INFO: Publishing image with 'latest' label: your.registry.tld/repo/foo_bar_baz
 
 These occur each time the plugin is invoked.
-
-## Known Issues
-
-  * None
-
-## TODO
-
-  * Toggle force pushing of `latest` via `.ci.yml`

--- a/src/main/java/com/groupon/jenkins/DockerComposeDotCi/DockerPublishUtils.java
+++ b/src/main/java/com/groupon/jenkins/DockerComposeDotCi/DockerPublishUtils.java
@@ -36,17 +36,13 @@ public class DockerPublishUtils {
     private ShellCommands buildTagAndPublishCommands(ShellCommands cmds, String composeBuild, String composeImage,
                                                      String hostOrgRepo, String label, String msg, Logger LOGGER) {
         LOGGER.info(msg);
-        if (label.equals("latest")) {
-            cmds.add(String.format("docker tag -f %s_%s %s:%s", composeBuild, composeImage, hostOrgRepo, label));
-        } else {
-            cmds.add(String.format("docker tag %s_%s %s:%s", composeBuild, composeImage, hostOrgRepo, label));
-        }
+        cmds.add(String.format("docker tag %s_%s %s:%s", composeBuild, composeImage, hostOrgRepo, label));
         cmds.add(String.format("docker push %s:%s", hostOrgRepo, label));
         return cmds;
     }
 
     public ShellCommands publishImages(ShellCommands cmds, String composeBuild, String composeImage, String ciTag,
-                                        String sha, String hostOrgRepo, boolean forcePushLatest, Logger LOGGER) {
+                                        String sha, String hostOrgRepo, Logger LOGGER) {
 
         if (ciTag != null) {
             // Publish with label as tag
@@ -56,14 +52,6 @@ public class DockerPublishUtils {
             // Publish with label as sha
             buildTagAndPublishCommands(cmds, composeBuild, composeImage, hostOrgRepo, sha,
                     String.format("Publishing image '%s' with SHA: %s:%s", composeImage, hostOrgRepo, sha), LOGGER);
-        }
-
-        if (forcePushLatest) {
-            // Publish as 'latest'
-            buildTagAndPublishCommands(cmds, composeBuild, composeImage, hostOrgRepo, "latest",
-                    String.format("Publishing image '%s' with 'latest' label: %s", composeImage, hostOrgRepo), LOGGER);
-        } else {
-            LOGGER.info("Force pushing 'latest' is disabled, skipping ...");
         }
         return cmds;
     }

--- a/src/test/java/com/groupon/jenkins/DockerComposeDotCi/DockerPublishPluginTest.java
+++ b/src/test/java/com/groupon/jenkins/DockerComposeDotCi/DockerPublishPluginTest.java
@@ -47,20 +47,15 @@ public class DockerPublishPluginTest {
     String expected_tag_cmd_with_tag = String.format("docker tag %s_%s %s:%s",
             composeBuildName, composeImage, dockerRepoName, dotCiTag);
     String expected_push_cmd_with_tag = String.format("docker push %s:%s", dockerRepoName, dotCiTag);
-    String expected_tag_cmd_with_latest = String.format("docker tag -f %s_%s %s:%s",
-            composeBuildName, composeImage, dockerRepoName, "latest");
-    String expected_push_cmd_with_latest = String.format("docker push %s:%s", dockerRepoName, "latest");
     String expected_first_command_sha = expected_tag_cmd_with_sha;
     String expected_first_command_tag = expected_tag_cmd_with_tag;
     String expected_second_command_sha = expected_push_cmd_with_sha;
     String expected_second_command_tag = expected_push_cmd_with_tag;
-    String expected_third_command = expected_tag_cmd_with_latest;
-    String expected_fourth_command = expected_push_cmd_with_latest;
 
     @Test
     public void should_publish_sha_as_label_if_tag_is_null() {
         ShellCommands final_cmds = utils.publishImages(cmds, composeBuildName,
-                composeImage, null, sha, dockerRepoName, false, LOGGER);
+                composeImage, null, sha, dockerRepoName, LOGGER);
 
         String cmd_lines[] = final_cmds.toShellScript().split("\\r?\\n");
 
@@ -74,7 +69,7 @@ public class DockerPublishPluginTest {
     @Test
     public void should_publish_tag_as_label_if_there_is_one() {
         ShellCommands final_cmds = utils.publishImages(cmds, composeBuildName,
-                composeImage, dotCiTag, sha, dockerRepoName, false, LOGGER);
+                composeImage, dotCiTag, sha, dockerRepoName, LOGGER);
 
         String cmd_lines[] = final_cmds.toShellScript().split("\\r?\\n");
 
@@ -86,51 +81,23 @@ public class DockerPublishPluginTest {
     }
 
     @Test
-    public void should_force_push_latest_if_enabled() {
+    public void should_run_the_correct_commands_for_sha() {
         ShellCommands final_cmds = utils.publishImages(cmds, composeBuildName,
-                composeImage, dotCiTag, sha, dockerRepoName, true, LOGGER);
-
-        String cmd_lines[] = final_cmds.toShellScript().split("\\r?\\n");
-
-        String tag_cmd = cmd_lines[5];
-        String push_cmd = cmd_lines[7];
-
-        Assert.assertEquals(tag_cmd, expected_tag_cmd_with_latest);
-        Assert.assertEquals(push_cmd, expected_push_cmd_with_latest);
-    }
-
-    @Test
-    public void should_not_force_push_latest_if_disabled() {
-        ShellCommands final_cmds = utils.publishImages(cmds, composeBuildName,
-                composeImage, dotCiTag, sha, dockerRepoName, false, LOGGER);
-
-        String cmd_lines[] = final_cmds.toShellScript().split("\\r?\\n");
-
-        Assert.assertEquals(cmd_lines.length, 4);  // When pushing 'latest' we have 8 commands
-    }
-
-    @Test
-    public void should_run_the_correct_commands_for_sha_and_latest_publish() {
-        ShellCommands final_cmds = utils.publishImages(cmds, composeBuildName,
-                composeImage, null, sha, dockerRepoName, true, LOGGER);
+                composeImage, null, sha, dockerRepoName, LOGGER);
 
         String cmd_lines[] = final_cmds.toShellScript().split("\\r?\\n");
 
         String first_cmd = cmd_lines[1];
         String second_cmd = cmd_lines[3];
-        String third_cmd = cmd_lines[5];
-        String fourth_cmd = cmd_lines[7];
 
         Assert.assertEquals(first_cmd, expected_first_command_sha);
         Assert.assertEquals(second_cmd, expected_second_command_sha);
-        Assert.assertEquals(third_cmd, expected_third_command);
-        Assert.assertEquals(fourth_cmd, expected_fourth_command);
     }
 
     @Test
-    public void should_run_the_correct_commands_for_tag_and_no_latest_publish() {
+    public void should_run_the_correct_commands_for_tag() {
         ShellCommands final_cmds = utils.publishImages(cmds, composeBuildName,
-                composeImage, dotCiTag, dotCiTag, dockerRepoName, false, LOGGER);
+                composeImage, dotCiTag, dotCiTag, dockerRepoName, LOGGER);
 
         String cmd_lines[] = final_cmds.toShellScript().split("\\r?\\n");
 


### PR DESCRIPTION
As of docker 1.12, the "-f" flag for the tag command has been removed.
This means that the "latest" label can no longer be a special case.
